### PR TITLE
fix vanishing questions by bumping angular version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": ">=1.3.x",
+    "angular": "1.6.1",
     "angular-sanitize": ">=1.3.x",
     "angular-translate": "2.x",
     "angular-ui-sortable": "0.13.x",


### PR DESCRIPTION
Fixes the vanishing questions when dragging to further pages (down).

![angular-surveys-fix](https://user-images.githubusercontent.com/562614/35265718-d2dbfd06-0018-11e8-9429-7283aba9b884.gif)
